### PR TITLE
PM-5764

### DIFF
--- a/lib/active_record/base_without_table.rb
+++ b/lib/active_record/base_without_table.rb
@@ -25,6 +25,10 @@ module ActiveRecord
     self.abstract_class = true
 
     class << self
+      def new(args)
+        super(args)
+      end
+
       def connection
         ConnectionAdapters::NullAdapter.new(super)
       end


### PR DESCRIPTION
Define `new` method so we don't rely on Rails 5.2 changes when inheriting from `ActiveRecord::BaseWithoutTable`

See: https://github.com/rails/rails/commit/d4007d5a54b60bd6924eeffb52c126ed32e9f31f
